### PR TITLE
avoiding viewcontroller creation for undefined side windows

### DIFF
--- a/Classes/DeMarcelpociotSidemenuSideMenu.m
+++ b/Classes/DeMarcelpociotSidemenuSideMenu.m
@@ -16,6 +16,9 @@ UIViewController * TiSideMenuControllerForViewProxy(TiViewProxy * proxy);
 
 UIViewController * TiSideMenuControllerForViewProxy(TiViewProxy * proxy)
 {
+    if (proxy == nil) {
+        return nil;
+    }
     [[proxy view] setAutoresizingMask:UIViewAutoresizingNone];
     
     //make the proper resize !


### PR DESCRIPTION
This PR allows to be able to set only one side menu window. In particular, if one of the side window arguments was left undefined, the corresponding viewcontroller would be created anyway, leading to Titanium complaining about creating a TiViewController without a corresponding ViewProxy, and to the presentation of an empty window at runtime.
